### PR TITLE
Check for storage engine type neo4j

### DIFF
--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -3,6 +3,7 @@ import { exec } from 'child_process';
 import { createCommand } from 'commander';
 import { promises as fs } from 'fs';
 import * as path from 'path';
+import { StorageEngineType } from '../types';
 import { parseConfigYaml } from '../util/parseConfig';
 
 export function run() {
@@ -40,9 +41,13 @@ export function run() {
 
           // And finally call command to save if we have a storage endpoint defined.
           if (config.storage) {
-            await exec(
-              `yarn j1-integration neo4j push -i ${integration.instanceId} -d ${integration.directory}/.j1-integration`,
-            );
+            if (config.storage.engine === StorageEngineType.Neo4j) {
+              await exec(
+                `yarn j1-integration neo4j push -i ${integration.instanceId} -d ${integration.directory}/.j1-integration`,
+              );
+            } else {
+              console.log('Invalid storage engine type ', config.storage.engine);
+            }
           }
         } else {
           console.log(

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,8 +6,12 @@ export type StarbaseIntegration<TConfig = any> = {
   config?: TConfig;
 };
 
+export enum StorageEngineType {
+  Neo4j = 'neo4j'
+}
+
 export type StarbaseStorage<TStorageConfig = any> = {
-  engine: string;
+  engine: StorageEngineType;
   config: TStorageConfig;
 };
 


### PR DESCRIPTION
This isn't a big deal, but checks that `storage.engine` is indeed `neo4j`. If not there, or not `neo4j`, it should not try to push data.