### PR TITLE
chore(yarn): Pin Node at v14 and Yarn at v1 for Volta users

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,5 +38,9 @@
     "@jupiterone/integration-sdk-dev-tools": "^8.4.4",
     "@types/js-yaml": "^4.0.5",
     "@types/nodegit": "^0.27.7"
+  },
+  "volta": {
+    "node": "14.19.0",
+    "yarn": "1.22.17"
   }
 }


### PR DESCRIPTION
Volta is a Node and Yarn version manager, much like nvm.  You can specify which version(s) in your package.json for a developer's machine to use automatically.

Without this change, the installation failed on my environment, when it was defaulting to use Node v16+