### PR TITLE
Display Neo4J browser URI in CLI after run

### DIFF
--- a/src/starbase/execution.ts
+++ b/src/starbase/execution.ts
@@ -48,6 +48,11 @@ async function executeStarbase(
     await writeIntegrationConfig(integration);
     await executeIntegration(integration, starbaseConfig);
   }
+  console.log(
+    `open ${
+      process.env.NEO4J_BROWSER_URI ?? 'http://localhost:7474/browser/'
+    } to browse your Neo4J graph.`,
+  );
 }
 
 export { executeStarbase, OnSkipIntegrationExecutionFunctionParams };


### PR DESCRIPTION
As a minor UX improvement, display the Neo4J browser URI in the CLI after run completes. This is clickable in most terminals, and new users won't have to dig the URI out of the docker docs. 