### PR TITLE
Adding APOC and GDS libraries to Neo4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ and this project adheres to
 
 - Commands to wipe and wipe-all now support the ability to wipe data in the
 Neo4j database, either by integrationID or completely.
-- The Neo4j Docker instance now includes the GDS and APOC libraries.
+- The additional `yarn neo4j:start:plugins` command starts the Neo4j Docker
+  image including the GDS and APOC libraries.
 ### Changed
 
 - Commands now only include setup and run. The update-integrations command has

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- Commands to wipe and wipe-all now support the ability to wipe data in the
+Neo4j database, either by integrationID or completely.
+- The Neo4j Docker instance now includes the GDS and APOC libraries.
 ### Changed
 
 - Commands now only include setup and run. The update-integrations command has

--- a/docker/README.md
+++ b/docker/README.md
@@ -18,7 +18,8 @@ Once the Neo4j server is running, you can access the Neo4j browser at
 default username to `neo4j` and the default password to `devpass`.
 
 The provided Neo4j configuration includes access to the standard Neo4j command
-set as well as the Graph Data Science and APOC libraries.  For more information
+set. Additionally, the `yarn neo4j:start:plugins` command will start the Neo4j
+instance including the Graph Data Science and APOC libraries.  For more information
 on their included functionality and proper use, see their docuementation here:
 
 [Graph Data Science (GDS)](https://neo4j.com/docs/graph-data-science/current/)

--- a/docker/README.md
+++ b/docker/README.md
@@ -17,6 +17,14 @@ Once the Neo4j server is running, you can access the Neo4j browser at
 <http://localhost:7474/browser/>. The `neo4j.yml` docker-compose config sets the
 default username to `neo4j` and the default password to `devpass`.
 
+The provided Neo4j configuration includes access to the standard Neo4j command
+set as well as the Graph Data Science and APOC libraries.  For more information
+on their included functionality and proper use, see their docuementation here:
+
+[Graph Data Science (GDS)](https://neo4j.com/docs/graph-data-science/current/)
+
+[Awesome Procedures on Cypher (APOC)](https://neo4j.com/labs/apoc/)
+
 NOTE: An existing installation of Docker Engine and Docker Composer are needed
 to use the above commands. [Docker Desktop](https://docs.docker.com/desktop/)
 for Windows and Mac includes Docker Composer. Linux users will need to install

--- a/docker/neo4j.yml
+++ b/docker/neo4j.yml
@@ -13,6 +13,3 @@ services:
       - ./.neo4j/plugins:/plugins
     environment:
       - NEO4J_AUTH=neo4j/devpass
-      - NEO4JLABS_PLUGINS=["graph-data-science", "apoc"]
-      - NEO4J_dbms_security_procedures_whitelist=gds.*, apoc.*
-      - NEO4J_dbms_security_procedures_unrestricted=gds.*, apoc.*

--- a/docker/neo4j.yml
+++ b/docker/neo4j.yml
@@ -12,4 +12,7 @@ services:
       - ./.neo4j/import:/var/lib/neo4j/import
       - ./.neo4j/plugins:/plugins
     environment:
-      NEO4J_AUTH: neo4j/devpass
+      - NEO4J_AUTH=neo4j/devpass
+      - NEO4JLABS_PLUGINS=["graph-data-science", "apoc"]
+      - NEO4J_dbms_security_procedures_whitelist=gds.*, apoc.*
+      - NEO4J_dbms_security_procedures_unrestricted=gds.*, apoc.*

--- a/docker/neo4jplugins.yml
+++ b/docker/neo4jplugins.yml
@@ -1,0 +1,6 @@
+services:
+  neo4j:
+    environment:
+      - NEO4JLABS_PLUGINS=["graph-data-science", "apoc"]
+      - NEO4J_dbms_security_procedures_whitelist=gds.*, apoc.*
+      - NEO4J_dbms_security_procedures_unrestricted=gds.*, apoc.*

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "starbase": "ts-node ./src/index.ts",
     "starbase:help": "ts-node ./src/index.ts -h",
     "neo4j:start": "docker-compose -f docker/neo4j.yml up -d",
+    "neo4j:start:plugins": "docker-compose -f docker/neo4j.yml -f docker/neo4jplugins.yml up -d",
     "neo4j:stop": "docker-compose -f docker/neo4j.yml down",
     "format": "prettier --write '**/*.{js,ts,md,json}'",
     "lint": "eslint --ext .js,.ts",


### PR DESCRIPTION
Updating Docker composer file to include necessary environment values to enable GDS and APOC libraries in Neo4j database.