### PR TITLE
Fix for Starbase setup error of new integrations

### DIFF
--- a/src/starbase/setup.ts
+++ b/src/starbase/setup.ts
@@ -27,7 +27,6 @@ async function setupStarbase(config: StarbaseConfig) {
 }
 
 async function installIntegrationDependencies(directory: string) {
-  console.log(`APAPAP  yarn --cwd ${directory} install`);
   return executeWithLogging(`yarn --cwd ${directory} install`);
 }
 

--- a/src/starbase/setup.ts
+++ b/src/starbase/setup.ts
@@ -14,10 +14,10 @@ async function setupStarbase(config: StarbaseConfig) {
   let configErrorCount = 0;
   for (const integration of config.integrations) {
     await setupIntegration(integration);
+    await installIntegrationDependencies(integration.directory);
     if (!(await checkInstanceConfigFields(integration))) {
       configErrorCount++;
     }
-    await installIntegrationDependencies(integration.directory);
   }
   if (configErrorCount > 0) {
     console.error(
@@ -27,6 +27,7 @@ async function setupStarbase(config: StarbaseConfig) {
 }
 
 async function installIntegrationDependencies(directory: string) {
+  console.log(`APAPAP  yarn --cwd ${directory} install`);
   return executeWithLogging(`yarn --cwd ${directory} install`);
 }
 


### PR DESCRIPTION
We need to installIntegrationDependencies before we attempt to checkInstanceConfigFields otherwise the dynamic import of the index file will throw errors.  This issue was introduced in https://github.com/JupiterOne/starbase/pull/47.