### PR TITLE
Add clone options with certificateCheck callback

### DIFF
--- a/src/starbase/setup.ts
+++ b/src/starbase/setup.ts
@@ -1,4 +1,4 @@
-import { Clone, Reference, Repository } from 'nodegit';
+import { Clone, CloneOptions, Reference, Repository } from 'nodegit';
 import { StarbaseConfig, StarbaseIntegration } from './types';
 import { isDirectoryPresent } from '@jupiterone/integration-sdk-runtime';
 import { executeWithLogging } from './process';
@@ -83,7 +83,15 @@ async function setupIntegration(integration: StarbaseIntegration) {
   if (await isDirectoryPresent(integration.directory)) {
     await updateIntegrationDirectory(integration.directory);
   } else {
-    await Clone.clone(integration.gitRemoteUrl, integration.directory);
+    const options: CloneOptions = {
+      fetchOpts: {
+        callbacks: {
+          certificateCheck: () => 0,
+        },
+      },
+    };
+
+    await Clone.clone(integration.gitRemoteUrl, integration.directory, options);
   }
 }
 


### PR DESCRIPTION
Attempt to resolve issue some users are seeing when `yarn setup` is attempting to clone the integration repos.

After doing to digging it appears this is a known issue with `nodegit`/`libgit2` on some OSX machines. Can see `nodegit` reference this issue in their example here: https://github.com/nodegit/nodegit/blob/master/examples/clone.js#L14

Issue posted here: #50 