### PR TITLE
Load .env environment variable values into starbase runtime

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "starbase": "./bin/starbase"
   },
   "scripts": {
-    "starbase": "ts-node ./src/index.ts",
+    "starbase": "ts-node --require dotenv/config ./src/index.ts",
     "starbase:help": "ts-node ./src/index.ts -h",
     "neo4j:start": "docker-compose -f docker/neo4j.yml up -d",
     "neo4j:stop": "docker-compose -f docker/neo4j.yml down",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2115,6 +2115,11 @@ dotenv-expand@^5.1.0:
   resolved "https://registry.yarnpkg.com/dotenv-expand/-/dotenv-expand-5.1.0.tgz#3fbaf020bfd794884072ea26b1e9791d45a629f0"
   integrity sha512-YXQl1DSa4/PQyRfgrv6aoNjhasp/p4qs9FjJ4q4cQk+8m4r6k4ZSiEyytKG8f8W9gi8WsQtIObNmKd+tMzNTmA==
 
+dotenv@^16.0.0:
+  version "16.0.0"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.0.0.tgz#c619001253be89ebb638d027b609c75c26e47411"
+  integrity sha512-qD9WU0MPM4SWLPJy/r2Be+2WgQj8plChsyrCNQzW/0WjvcJQiKQJ9mH3ZgB3fxbUUxgc/11ZJ0Fi5KiimWGz2Q==
+
 dotenv@^8.2.0:
   version "8.6.0"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.6.0.tgz#061af664d19f7f4d8fc6e4ff9b584ce237adcb8b"


### PR DESCRIPTION
This would add **dotenv** as a dev dependency, as a low-effort solution to import user-defined environment variables from **.env**

e.g:
.env
```
ENV_VARIABLE_VALUE=123
```

config.yaml
```
...
  someProperty: ${ENV_VARIABLE_VALUE}
```