### PR TITLE
Disable Schema Validation

### DIFF
--- a/src/starbase/integration.ts
+++ b/src/starbase/integration.ts
@@ -2,7 +2,9 @@ import { StarbaseConfig, StarbaseIntegration } from './types';
 import { executeWithLogging } from './process';
 
 async function collectIntegrationData(integrationDirectory: string) {
-  await executeWithLogging(`yarn --cwd ${integrationDirectory} start;`);
+  await executeWithLogging(
+    `yarn --cwd ${integrationDirectory} start --disable-schema-validation;`,
+  );
 }
 
 async function writeIntegrationDataToNeo4j(


### PR DESCRIPTION
Integrations may fail due to the `data-model` validation, but I think that shouldn't happen in a managed context like starbase.